### PR TITLE
Update Invoke-SqliteQuery.ps1

### DIFF
--- a/PSSQLite/Invoke-SqliteQuery.ps1
+++ b/PSSQLite/Invoke-SqliteQuery.ps1
@@ -538,7 +538,9 @@
                 }
                 'SingleValue'
                 {
-                    $ds.Tables[0] | Select-Object -ExpandProperty $ds.Tables[0].Columns[0].ColumnName
+                    if($ds.Tables.Count -gt 0 -and $ds.Tables[0].Columns.Count -gt 0){
+                        $ds.Tables[0] | Select-Object -ExpandProperty $ds.Tables[0].Columns[0].ColumnName
+                    }
                 }
             }
         }


### PR DESCRIPTION
Check that a value is returned when using "SingleValue".

If you don't do this and the "SingleValue" is actually select 0 rows then an exception is thrown. This will, instead, return nothing. 